### PR TITLE
added max tasks per child

### DIFF
--- a/celery/start.sh
+++ b/celery/start.sh
@@ -6,4 +6,4 @@ echo Starting Celery.
 cd $PROJECT_ROOT
 cd etabotsite
 
-celery -A etabotsite worker -l info
+celery -A etabotsite worker -l info --max-tasks-per-child=50


### PR DESCRIPTION
This is the untested max tasks per child line for the celery task manager. 