### PR TITLE
Add celery task id to response

### DIFF
--- a/etabotsite/etabotapp/celery_tracking.py
+++ b/etabotsite/etabotapp/celery_tracking.py
@@ -7,6 +7,7 @@ import traceback
 import logging
 import celery as clry
 from etabotapp.compression import compress_payload
+from .exceptions import TaskFailedError
 celery = clry.Celery()
 celery.config_from_object('django.conf:settings')
 
@@ -52,45 +53,48 @@ def send_celery_task_with_tracking(name, args, owner=None, compress=False, **kwa
     return result
 
 
-def celery_task_update(func):
+def celery_task_update(raise_exceptions: bool = False):
     """Decorator for:
     Updating a job in the database (as CeleryTask) """
-    @functools.wraps(func)
-    def inner(*args, **kwargs):
-        error_str = ''
-        try:
-            logger.debug('celery_task_update decorator is starting celery function. ')
-            result = func(*args, **kwargs)
-            result_status = 'DN'
-            logger.info('Celery task function executed.')
-        except Exception as e:
-            traceback_str = str(traceback.format_exc())
-            logger.error('Celery task failed due to "{}"'.format(e))
-            logger.error('Celery task failed due to "{}"'.format(traceback_str))
-            error_str = str(e) + traceback_str
-            result_status = 'FL'
-            result = None
+    def celery_task_update_with_exception(func):
+        @functools.wraps(func)
+        def inner(*args, **kwargs):
+            task_id = kwargs.get("task_id")
+            error_str = ''
+            try:
+                logger.debug('celery_task_update decorator is starting celery function. ')
+                result = func(*args, **kwargs)
+                result_status = 'DN'
+                logger.info('Celery task function executed.')
+            except Exception as e:
+                traceback_str = str(traceback.format_exc())
+                logger.error('Celery task {} failed due to "{}"'.format(task_id, e))
+                logger.error('Celery task {} failed due to "{}"'.format(task_id, traceback_str))
+                error_str = str(e) + traceback_str
+                result_status = 'FL'
+                result = None
 
-        # End timer
-        task_id = kwargs.get("task_id")
-        if task_id is not None:
-            celery_task_records = CeleryTask.objects.all().filter(pk=task_id)
-            if len(celery_task_records) == 1:
-                celery_task_record = celery_task_records[0]
-                celery_task_record.end_time = datetime.datetime.now()
-                celery_task_record.status = result_status
-                meta_data = celery_task_record.meta_data
-                if meta_data is None:
-                    meta_data = {}
-                meta_data['error_str'] = error_str
-                celery_task_record.meta_data = meta_data
-                celery_task_record.save()
-                logger.info('updated celery task_id={} with status={}'.format(task_id, result_status))
+            # End timer
+            if task_id is not None:
+                celery_task_records = CeleryTask.objects.all().filter(pk=task_id)
+                if len(celery_task_records) == 1:
+                    celery_task_record = celery_task_records[0]
+                    celery_task_record.end_time = datetime.datetime.now()
+                    celery_task_record.status = result_status
+                    meta_data = celery_task_record.meta_data
+                    if meta_data is None:
+                        meta_data = {}
+                    meta_data['error_str'] = error_str
+                    celery_task_record.meta_data = meta_data
+                    celery_task_record.save()
+                    logger.info('updated celery task_id={} with status={}'.format(task_id, result_status))
+                else:
+                    logger.error('not unique celery_task_record found, length={}'.format(len(celery_task_records)))
             else:
-                logger.error('not unique celery_task_record found, length={}'.format(len(celery_task_records)))
-        else:
-            logger.warning('no celery task id passed for tracking.')
-        return result
+                logger.warning('no celery task id passed for tracking.')
 
-    return inner
-
+            if raise_exceptions and error_str:
+                raise TaskFailedError('Celery task {} failed due to "{}"'.format(task_id, error_str))
+            return result
+        return inner
+    return celery_task_update_with_exception

--- a/etabotsite/etabotapp/django_tasks.py
+++ b/etabotsite/etabotapp/django_tasks.py
@@ -93,8 +93,8 @@ def generate_critical_path(
 
 
 @shared_task
-@celery_task_update
 @decompress
+@celery_task_update(raise_exceptions=True)
 def generate_critical_path_jira(
         issues_dict: Dict,
         start_date_field_name: str,

--- a/etabotsite/etabotapp/exceptions.py
+++ b/etabotsite/etabotapp/exceptions.py
@@ -1,0 +1,2 @@
+class TaskFailedError(Exception):
+    pass

--- a/etabotsite/etabotapp/views.py
+++ b/etabotsite/etabotapp/views.py
@@ -1,5 +1,3 @@
-
-
 from django.shortcuts import render
 from django.contrib.auth.models import User
 from django.http import HttpResponse
@@ -20,6 +18,7 @@ from .models import TMS, Project
 from .models import oauth
 from .permissions import IsOwnerOrReadOnly, IsOwner
 from etabotapp.TMSlib.JIRA_API import JIRA_wrapper
+from .exceptions import TaskFailedError
 import etabotapp.TMSlib.TMS as TMSlib
 # import etabotapp.TMSlib.data_conversion as dc
 from .user_activation import ActivationProcessor, ResponseCode
@@ -544,26 +543,42 @@ class CriticalPathsViewJIRAplugin(APIView):
                 status=status.HTTP_400_BAD_REQUEST)
 
         eta_date_field_name = post_data.get('eta_date_field_name')
-
+        celery_task_id = None
+        task_path = 'etabotapp.django_tasks.generate_critical_path_jira'
         try:
             result = send_celery_task_with_tracking(
-                'etabotapp.django_tasks.generate_critical_path_jira',
+                task_path,
                 (issues_dict, start_date_field_name, eta_date_field_name, final_nodes, params),
                 owner=self.request.user,
                 compress=True)
-
+            celery_task_id = result.id
             json_response = result.get()
+            if json_response:
+                return Response(
+                    data=json_response,
+                    status=status.HTTP_200_OK
+                )
+            else:
+                raise TaskFailedError("{} returned None as a response".format(task_path))
+        except TaskFailedError as e:
+            logger.warning("Celery task failed. task ID {}".format(celery_task_id))
+            logger.error(e)
             return Response(
-                data=json_response,
-                status=status.HTTP_200_OK)
+                {
+                    "error": "An internal server error has occurred.",
+                    "error_id": celery_task_id,
+                },
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
         except Exception as e:
             error_message = str(e)
             logger.warning(error_message)
             return Response(
                 {
-                    "error": error_message
+                    "error": error_message,
                 },
-                status=status.HTTP_400_BAD_REQUEST)
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
 
 class EstimateTMSView(APIView):


### PR DESCRIPTION
Apply a few other fixes for smoother error handling:
- Re-raise exception in celery task decorator/logger to propagate to email 
- Fix task id retrieval in celery task decorator
- Cleanup error handling in jira plugin view

<img width="1066" height="75" alt="image" src="https://github.com/user-attachments/assets/60874505-a5d3-464f-a0ad-ae697fffa99a" />
